### PR TITLE
Adicionado informações simultâneas para sandbox e produção

### DIFF
--- a/PGA_Controller.class.php
+++ b/PGA_Controller.class.php
@@ -11,6 +11,8 @@ class PGA_Controller {
         if ('yes' == $pga_gateway->sandbox) {
             $this->baseUrlAssinatura = 'https://ws.sandbox.pagseguro.uol.com.br/v2/pre-approvals/';
             $this->urlAssinaturasCheckout = 'https://sandbox.pagseguro.uol.com.br/v2/pre-approvals/request.html';
+            $this->gateway->token = $this->gateway->token_sandbox;
+            $this->gateway->email = $this->gateway->email_sandbox;
         }
     }
 
@@ -64,7 +66,7 @@ class PGA_Controller {
             'ajax_url' => admin_url('admin-ajax.php'),
             'processando_compra' => __('Aguarde... Você está sendo redirecionado para o Pagseguro', 'pagseguro-assinaturas-rcs')
         );
-        if(!empty($_GET['code'])) {
+        if (!empty($_GET['code'])) {
             $dadosPagseguro['processando_compra'] = __('Aguarde... Estamos atualizando o status do seu pagamento', 'pagseguro-assinaturas-rcs');
         }
         wp_localize_script('pagseguro-assinaturas-rcs-checkout', 'arrPagseguro', $dadosPagseguro);
@@ -103,7 +105,7 @@ class PGA_Controller {
      * @param  string $title   Email title.
      * @param  string $message Email message.
      *
-     * @return void 
+     * @return void
      */
     function send_email($email, $subject, $title, $message) {
         global $woocommerce;

--- a/PGA_Gateway.class.php
+++ b/PGA_Gateway.class.php
@@ -26,7 +26,9 @@ class PGA_Gateway extends WC_Payment_Gateway {
         // API options.
         $this->api = $this->get_option('api', 'tc');
         $this->token = $this->get_option('token');
+        $this->token_sandbox = $this->get_option('token_sandbox');
         $this->email = $this->get_option('email');
+        $this->email_sandbox = $this->get_option('email_sandbox');
         $this->token_notificacao = $this->get_option('token_notificacao');
         $this->outras_formas_pagseguro = $this->get_option('outras_formas_pagseguro', 'yes');
 
@@ -127,6 +129,20 @@ class PGA_Gateway extends WC_Payment_Gateway {
                 'title' => __('Email do Pagseguro', 'pagseguro-assinaturas-rcs'),
                 'type' => 'text',
                 'description' => __('Digite seu email do pagseguro; ele é necessário para finalizar o pagamento.', 'pagseguro-assinaturas-rcs'),
+                'desc_tip' => true,
+                'default' => ''
+            ),
+            'token_sandbox' => array(
+                'title' => __('Token de acesso - SandBox', 'pagseguro-assinaturas-rcs'),
+                'type' => 'text',
+                'description' => __('Digite seu Token de Accesso no SandBox; ele é necessário para finalizar o pagamento com este recurso ativado.', 'pagseguro-assinaturas-rcs'),
+                'desc_tip' => true,
+                'default' => ''
+            ),
+            'email_sandbox' => array(
+                'title' => __('Email do Pagseguro - SandBox', 'pagseguro-assinaturas-rcs'),
+                'type' => 'text',
+                'description' => __('Digite seu email do pagseguro no SandBox; ele é necessário para finalizar o pagamento com este recurso ativado.', 'pagseguro-assinaturas-rcs'),
                 'desc_tip' => true,
                 'default' => ''
             ),
@@ -506,4 +522,5 @@ class PGA_Gateway extends WC_Payment_Gateway {
             $this->log->add('pagseguro-assinaturas-rcs', $debug_log);
         }
     }
+
 }


### PR DESCRIPTION
Foi adicionado algumas linhas para evitar a substituição dos dados em caso de sandbox. Agora o usuário pode adicionar as duas informações nas configurações e o sistema usará a configuração de acordo com a opção marcada ou não de sandbox.